### PR TITLE
Provide a reference parser implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ Developers should use the format `key:value` to define additional metadata (e.g.
 Both `key` and `value` must consist of non-whitespace characters, which are not colons. Only one colon separates the `key` and `value`.
 
 
+## Example parser
+An example parser with a formal grammar definition for todo.txt entries written in the Go language is available as [example_parser.go].
 
 
 [Getting Things Done]: https://en.wikipedia.org/wiki/Getting_Things_Done
 [Format Quick Reference Image]: /description.png
+[example_parser.go]: /example_parser.go

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ Both `key` and `value` must consist of non-whitespace characters, which are not 
 
 
 ## Example parser
-An example parser with a formal grammar definition for todo.txt entries written in the Go language is available as [example_parser.go].
+An example parser with a formal grammar definition for todo.txt entries written in the Go language is available as [example_parser.go]. You can also [see the example parse trees].
 
 
 [Getting Things Done]: https://en.wikipedia.org/wiki/Getting_Things_Done
 [Format Quick Reference Image]: /description.png
 [example_parser.go]: /example_parser.go
+[see the example parse trees]: /example_parser_output.txt

--- a/example_parser.go
+++ b/example_parser.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+
+	parsec "github.com/prataprc/goparsec"
+)
+
+func main() {
+	ast := parsec.NewAST("TODO", 1000)
+	// // chars -> [^:whitespace:]
+	// glyph := parsec.Token(`[[:graph:]]`, "GLYPH")
+
+	tag := ast.OrdChoice("TAG", nil,
+		parsec.Token(`[+][[:graph:]]+`, "PLUSTAG"),
+		parsec.Token(`[@][[:graph:]]+`, "ATTAG"),
+		parsec.Token(`[#][[:graph:]]+`, "HASHTAG"),
+	)
+	// // atTag -> "@" glyph+
+	// atTag := ast.And(one2one, ast.Token(`@`, "at"), ast.Many(many2many, glyph))
+
+	// // plusTag -> "+" glyph+
+	// plusTag := ast.And(one2one, ast.Token(`+`, "at"), ast.Many(many2many, glyph))
+
+	// // hashtag -> "#" glyph+
+	// hastTag := ast.And(one2one, ast.Token(`#`, "at"), ast.Many(many2many, glyph))
+
+	// kvPair -> ([^+@#] glyph*) ":" glyph+
+	kvPair := ast.And("KVPAIR", nil,
+		// we use this long regexp instead of :graph: to omit ':' There's probably a regexpy
+		// way of doing this better
+		parsec.Token(`[^#@+:][A-Za-z0-9!"#$%&'()*+,\-./;<=>?@[\\\]^_{|}~]*`, "KEY"),
+		parsec.TokenExact(":", "COLON"),
+		parsec.TokenExact(`[A-Za-z0-9!"#$%&'()*+,\-./;<=>?@[\\\]^_{|}~]+`, "VALUE"),
+	)
+
+	// word -> ([^+@#] glyph*) | ([+@#])
+	word := ast.OrdChoice("WORD", nil,
+		parsec.Token(`[^@#+][[:graph:]]*`, "WORD"),
+		parsec.Token(`[@#+]$`, "WORD"),
+	)
+
+	// token -> kvPair | word | hashTag | plusTag | atTag
+	token := ast.OrdChoice("TOKEN", nil, kvPair, word, tag)
+
+	// day -> [0-9]{2}
+	// month -> [0-9]{2}
+	// year -> [0-9]{4}
+	// date -> year "-" month "-" day
+	// createdDate -> date
+	createdDate := parsec.Token(`[0-9]{4}-[0-9]{2}-[0-9]{2}`, "CREATIONDATE")
+	// completeDate -> date
+	completeDate := parsec.Token(`[0-9]{4}-[0-9]{2}-[0-9]{2}`, "COMPLETIONDATE")
+
+	// priority -> "(" [A-Z] ")"
+	priority := parsec.Token(`\([A-Z]\)[[:space:]]+`, "PRIORITY")
+
+	// space -> :whitespace:*
+
+	// completeMArk -> "x"
+	completeMark := parsec.Token(`x[[:space:]]+`, "COMPLETED")
+
+	// TODO -> completeMark? priority? completeDate? createdDate? token+
+	TODO := ast.And("TODO", nil,
+		ast.OrdChoice("PREAMBLE", nil,
+			ast.And("PREAMBLE", nil,
+				completeMark,
+				ast.Maybe("PRIORITY", nil, priority),
+				ast.Maybe("COMPLETEDAT", nil, completeDate),
+				ast.Maybe("CREATEDAT", nil, createdDate),
+			),
+			ast.And("PREAMBLE", nil,
+				ast.Maybe("PRIORITY", nil, priority),
+				ast.Maybe("CREATEDAT", nil, createdDate),
+			),
+		),
+		ast.Many("WORDS", nil, token),
+	)
+
+	examples := []string{
+		"x (A) 2018-07-30 2018-07-31 Some todo item with +ProjectTag @atTag #hashtag and key:value pair",
+		"(A) Thank Mom for the meatballs @phone",
+		"(B) Schedule Goodwill pickup +GarageSale @phone",
+		"Post signs around the neighborhood +GarageSale",
+		"@GroceryStore Eskimo pies",
+		"(A) Thank Mom for the meatballs @phone",
+		"(B) Schedule Goodwill pickup +GarageSale @phone",
+		"(B) Schedule Goodwill pickup +GarageSale @phone",
+		"Post signs around the neighborhood +GarageSale",
+		"Really gotta call Mom (A) @phone @someday",
+		"(b) Get back to the boss",
+		"(B)->Submit TPS report",
+		"2011-03-02 Document +TodoTxt task format", // This is not a completion date because it's not complete
+		"(A) 2011-03-02 Call Mom",
+		"(A) Call Mom 2011-03-02",
+		"(A) Call Mom +Family +PeaceLoveAndHappiness @iphone @phone",
+		"Email SoAndSo at soandso@example.com",
+		"Learn how to add 2+2",
+		"x 2011-03-03 Call Mom", // this is a completion date
+		"xylophone lesson",
+		"X 2012-01-01 Make resolutions",
+		"(A) x Find ticket prices",
+		"x 2011-03-02 2011-03-01 Review Tim's pull request +TodoTxtTouch @github",
+		"Some example with key:value and due:2010-01-02",
+	}
+
+	for i, todo := range examples {
+		println()
+		fmt.Printf("[%v]: %s\n", i, todo)
+		scanner := parsec.NewScanner([]byte(todo))
+		ast.Parsewith(TODO, scanner)
+		ast.Prettyprint()
+		ast.Reset()
+	}
+}

--- a/example_parser.go
+++ b/example_parser.go
@@ -8,24 +8,13 @@ import (
 
 func main() {
 	ast := parsec.NewAST("TODO", 1000)
-	// // chars -> [^:whitespace:]
-	// glyph := parsec.Token(`[[:graph:]]`, "GLYPH")
 
 	tag := ast.OrdChoice("TAG", nil,
 		parsec.Token(`[+][[:graph:]]+`, "PLUSTAG"),
 		parsec.Token(`[@][[:graph:]]+`, "ATTAG"),
 		parsec.Token(`[#][[:graph:]]+`, "HASHTAG"),
 	)
-	// // atTag -> "@" glyph+
-	// atTag := ast.And(one2one, ast.Token(`@`, "at"), ast.Many(many2many, glyph))
 
-	// // plusTag -> "+" glyph+
-	// plusTag := ast.And(one2one, ast.Token(`+`, "at"), ast.Many(many2many, glyph))
-
-	// // hashtag -> "#" glyph+
-	// hastTag := ast.And(one2one, ast.Token(`#`, "at"), ast.Many(many2many, glyph))
-
-	// kvPair -> ([^+@#] glyph*) ":" glyph+
 	kvPair := ast.And("KVPAIR", nil,
 		// we use this long regexp instead of :graph: to omit ':' There's probably a regexpy
 		// way of doing this better
@@ -34,33 +23,20 @@ func main() {
 		parsec.TokenExact(`[A-Za-z0-9!"#$%&'()*+,\-./;<=>?@[\\\]^_{|}~]+`, "VALUE"),
 	)
 
-	// word -> ([^+@#] glyph*) | ([+@#])
 	word := ast.OrdChoice("WORD", nil,
 		parsec.Token(`[^@#+][[:graph:]]*`, "WORD"),
 		parsec.Token(`[@#+]$`, "WORD"),
 	)
 
-	// token -> kvPair | word | hashTag | plusTag | atTag
 	token := ast.OrdChoice("TOKEN", nil, kvPair, word, tag)
 
-	// day -> [0-9]{2}
-	// month -> [0-9]{2}
-	// year -> [0-9]{4}
-	// date -> year "-" month "-" day
-	// createdDate -> date
 	createdDate := parsec.Token(`[0-9]{4}-[0-9]{2}-[0-9]{2}`, "CREATIONDATE")
-	// completeDate -> date
 	completeDate := parsec.Token(`[0-9]{4}-[0-9]{2}-[0-9]{2}`, "COMPLETIONDATE")
 
-	// priority -> "(" [A-Z] ")"
 	priority := parsec.Token(`\([A-Z]\)[[:space:]]+`, "PRIORITY")
 
-	// space -> :whitespace:*
-
-	// completeMArk -> "x"
 	completeMark := parsec.Token(`x[[:space:]]+`, "COMPLETED")
 
-	// TODO -> completeMark? priority? completeDate? createdDate? token+
 	TODO := ast.And("TODO", nil,
 		ast.OrdChoice("PREAMBLE", nil,
 			ast.And("PREAMBLE", nil,

--- a/example_parser_output.txt
+++ b/example_parser_output.txt
@@ -1,0 +1,298 @@
+[0]: x (A) 2018-07-30 2018-07-31 Some todo item with +ProjectTag @atTag #hashtag and key:value pair
+TODO @ 0
+  PREAMBLE @ 0
+    *COMPLETED: "x "
+    *PRIORITY: "(A) "
+    *COMPLETIONDATE: "2018-07-30"
+    *CREATIONDATE: "2018-07-31"
+  WORDS @ 28
+    *WORD: "Some"
+    *WORD: "todo"
+    *WORD: "item"
+    *WORD: "with"
+    *PLUSTAG: "+ProjectTag"
+    *ATTAG: "@atTag"
+    *HASHTAG: "#hashtag"
+    *WORD: "and"
+    KVPAIR @ 80
+      *KEY: "key"
+      *COLON: ":"
+      *VALUE: "value"
+    *WORD: "pair"
+
+[1]: (A) Thank Mom for the meatballs @phone
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(A) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Thank"
+    *WORD: "Mom"
+    *WORD: "for"
+    *WORD: "the"
+    *WORD: "meatballs"
+    *ATTAG: "@phone"
+
+[2]: (B) Schedule Goodwill pickup +GarageSale @phone
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(B) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Schedule"
+    *WORD: "Goodwill"
+    *WORD: "pickup"
+    *PLUSTAG: "+GarageSale"
+    *ATTAG: "@phone"
+
+[3]: Post signs around the neighborhood +GarageSale
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "Post"
+    *WORD: "signs"
+    *WORD: "around"
+    *WORD: "the"
+    *WORD: "neighborhood"
+    *PLUSTAG: "+GarageSale"
+
+[4]: @GroceryStore Eskimo pies
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *ATTAG: "@GroceryStore"
+    *WORD: "Eskimo"
+    *WORD: "pies"
+
+[5]: (A) Thank Mom for the meatballs @phone
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(A) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Thank"
+    *WORD: "Mom"
+    *WORD: "for"
+    *WORD: "the"
+    *WORD: "meatballs"
+    *ATTAG: "@phone"
+
+[6]: (B) Schedule Goodwill pickup +GarageSale @phone
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(B) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Schedule"
+    *WORD: "Goodwill"
+    *WORD: "pickup"
+    *PLUSTAG: "+GarageSale"
+    *ATTAG: "@phone"
+
+[7]: (B) Schedule Goodwill pickup +GarageSale @phone
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(B) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Schedule"
+    *WORD: "Goodwill"
+    *WORD: "pickup"
+    *PLUSTAG: "+GarageSale"
+    *ATTAG: "@phone"
+
+[8]: Post signs around the neighborhood +GarageSale
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "Post"
+    *WORD: "signs"
+    *WORD: "around"
+    *WORD: "the"
+    *WORD: "neighborhood"
+    *PLUSTAG: "+GarageSale"
+
+[9]: Really gotta call Mom (A) @phone @someday
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "Really"
+    *WORD: "gotta"
+    *WORD: "call"
+    *WORD: "Mom"
+    *WORD: "(A)"
+    *ATTAG: "@phone"
+    *ATTAG: "@someday"
+
+[10]: (b) Get back to the boss
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "(b)"
+    *WORD: "Get"
+    *WORD: "back"
+    *WORD: "to"
+    *WORD: "the"
+    *WORD: "boss"
+
+[11]: (B)->Submit TPS report
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "(B)->Submit"
+    *WORD: "TPS"
+    *WORD: "report"
+
+[12]: 2011-03-02 Document +TodoTxt task format
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *CREATIONDATE: "2011-03-02"
+  WORDS @ 11
+    *WORD: "Document"
+    *PLUSTAG: "+TodoTxt"
+    *WORD: "task"
+    *WORD: "format"
+
+[13]: (A) 2011-03-02 Call Mom
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(A) "
+    *CREATIONDATE: "2011-03-02"
+  WORDS @ 15
+    *WORD: "Call"
+    *WORD: "Mom"
+
+[14]: (A) Call Mom 2011-03-02
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(A) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Call"
+    *WORD: "Mom"
+    *WORD: "2011-03-02"
+
+[15]: (A) Call Mom +Family +PeaceLoveAndHappiness @iphone @phone
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(A) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "Call"
+    *WORD: "Mom"
+    *PLUSTAG: "+Family"
+    *PLUSTAG: "+PeaceLoveAndHappiness"
+    *ATTAG: "@iphone"
+    *ATTAG: "@phone"
+
+[16]: Email SoAndSo at soandso@example.com
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "Email"
+    *WORD: "SoAndSo"
+    *WORD: "at"
+    *WORD: "soandso@example.com"
+
+[17]: Learn how to add 2+2
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "Learn"
+    *WORD: "how"
+    *WORD: "to"
+    *WORD: "add"
+    *WORD: "2+2"
+
+[18]: x 2011-03-03 Call Mom
+TODO @ 0
+  PREAMBLE @ 0
+    *COMPLETED: "x "
+    *missing: ""
+    *COMPLETIONDATE: "2011-03-03"
+    *missing: ""
+  WORDS @ 13
+    *WORD: "Call"
+    *WORD: "Mom"
+
+[19]: xylophone lesson
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "xylophone"
+    *WORD: "lesson"
+
+[20]: X 2012-01-01 Make resolutions
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "X"
+    *WORD: "2012-01-01"
+    *WORD: "Make"
+    *WORD: "resolutions"
+
+[21]: (A) x Find ticket prices
+TODO @ 0
+  PREAMBLE @ 0
+    *PRIORITY: "(A) "
+    *missing: ""
+  WORDS @ 4
+    *WORD: "x"
+    *WORD: "Find"
+    *WORD: "ticket"
+    *WORD: "prices"
+
+[22]: x 2011-03-02 2011-03-01 Review Tim's pull request +TodoTxtTouch @github
+TODO @ 0
+  PREAMBLE @ 0
+    *COMPLETED: "x "
+    *missing: ""
+    *COMPLETIONDATE: "2011-03-02"
+    *CREATIONDATE: "2011-03-01"
+  WORDS @ 24
+    *WORD: "Review"
+    *WORD: "Tim's"
+    *WORD: "pull"
+    *WORD: "request"
+    *PLUSTAG: "+TodoTxtTouch"
+    *ATTAG: "@github"
+
+[23]: Some example with key:value and due:2010-01-02
+TODO @ -1
+  PREAMBLE @ -1
+    *missing: ""
+    *missing: ""
+  WORDS @ 0
+    *WORD: "Some"
+    *WORD: "example"
+    *WORD: "with"
+    KVPAIR @ 18
+      *KEY: "key"
+      *COLON: ":"
+      *VALUE: "value"
+    *WORD: "and"
+    KVPAIR @ 32
+      *KEY: "due"
+      *COLON: ":"
+      *VALUE: "2010-01-02"


### PR DESCRIPTION
It is useful for implementers of tools that work with the todo.txt format to have a formal grammar and reference implementation to implement the format correctly.

I just had to write a parser, and while incomplete and likely incorrect (whitespace includes newlines, parser is for line, not file, etc...) it would be a good starting point and will very likely be useful for future implementers.

I would recommend that this is followed up by a formal grammar specification for the format.